### PR TITLE
Feature/cancel and retry transactions

### DIFF
--- a/data/migrations/1712172815782-add-cancel-transaction-type.ts
+++ b/data/migrations/1712172815782-add-cancel-transaction-type.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCancelTransactionType1712172815782
+  implements MigrationInterface
+{
+  name = 'AddCancelTransactionType1712172815782';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`stellar_transaction\` CHANGE \`type\` \`type\` enum ('create', 'confirm', 'consolidate', 'deliver', 'cancel') NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`stellar_transaction\` CHANGE \`type\` \`type\` enum ('create', 'confirm', 'consolidate', 'deliver') NOT NULL`,
+    );
+  }
+}

--- a/src/common/application/exceptions/stellar.error.ts
+++ b/src/common/application/exceptions/stellar.error.ts
@@ -4,6 +4,7 @@ export enum ERROR_CODES {
   CONFIRM_ORDER_ERROR = 'CONFIRM_ORDER_ERROR',
   CONSOLIDATE_ORDER_ERROR = 'CONSOLIDATE_ORDER_ERROR',
   DELIVER_ORDER_ERROR = 'DELIVER_ORDER_ERROR',
+  CANCEL_ORDER_ERROR = 'CANCEL_ORDER_ERROR',
   GENERIC_ERROR = 'GENERIC_ERROR',
   ORDER_UNABLE_TO_CREATE_ERROR = 'ORDER_UNABLE_TO_CREATE_ERROR',
   ORDER_UNABLE_TO_CONFIRM_ERROR = 'ORDER_UNABLE_TO_CONFIRM_ERROR',
@@ -21,6 +22,8 @@ export const ERROR_MESSAGES: { [key in ERROR_CODES]: string } = {
     'An error occurred while consolidating order transaction',
   [ERROR_CODES.DELIVER_ORDER_ERROR]:
     'An error occurred while delivering order transaction',
+  [ERROR_CODES.CANCEL_ORDER_ERROR]:
+    'An error occurred while canceling order transaction',
   [ERROR_CODES.GENERIC_ERROR]: 'An error occurred in the Stellar service',
   [ERROR_CODES.ORDER_UNABLE_TO_CREATE_ERROR]: 'The order cannot be created',
   [ERROR_CODES.ORDER_UNABLE_TO_CONFIRM_ERROR]: 'The order cannot be confirmed',

--- a/src/common/application/repository/stellar.repository.interface.ts
+++ b/src/common/application/repository/stellar.repository.interface.ts
@@ -16,4 +16,5 @@ export interface IStellarRepository {
   confirmOrder(amounts: IAssetAmount[]): Promise<ISubmittedTransaction>;
   consolidateOrder(amounts: IAssetAmount[]): Promise<ISubmittedTransaction>;
   deliverOrder(amounts: IAssetAmount[]): Promise<ISubmittedTransaction>;
+  cancelOrder(hash: string): Promise<ISubmittedTransaction>;
 }

--- a/src/modules/odoo/application/dto/cancel-order.dto.ts
+++ b/src/modules/odoo/application/dto/cancel-order.dto.ts
@@ -1,0 +1,10 @@
+import { Equals } from 'class-validator';
+
+import { STATE } from '@/modules/odoo/application/services/odoo.state';
+
+import { SaleOrderDto } from './sale-order.dto';
+
+export class CancelOrderDto extends SaleOrderDto {
+  @Equals(STATE.CANCEL)
+  state: string;
+}

--- a/src/modules/odoo/application/services/odoo.state.ts
+++ b/src/modules/odoo/application/services/odoo.state.ts
@@ -3,4 +3,5 @@ export enum STATE {
   SALE = 'sale',
   ASSIGNED = 'assigned',
   DONE = 'done',
+  CANCEL = 'cancel',
 }

--- a/src/modules/odoo/interface/__test__/odoo.e2e.spec.ts
+++ b/src/modules/odoo/interface/__test__/odoo.e2e.spec.ts
@@ -7,6 +7,7 @@ import { STELLAR_REPOSITORY } from '@/common/application/repository/stellar.repo
 import { StellarService } from '@/modules/stellar/application/services/stellar.service';
 import { TRANSACTION_TYPE } from '@/modules/stellar/domain/stellar-transaction.domain';
 
+import { CancelOrderDto } from '../../application/dto/cancel-order.dto';
 import { ConfirmOrderDto } from '../../application/dto/confirm-order.dto';
 import { ConsolidateOrderDto } from '../../application/dto/consolidate-order.dto';
 import { CreateOrderDto } from '../../application/dto/create-order.dto';
@@ -128,5 +129,24 @@ describe('Odoo Module', () => {
 
     expect(spyPush).toBeCalledTimes(1);
     expect(spyPush).toBeCalledWith(TRANSACTION_TYPE.DELIVER, body.sale_id);
+  });
+
+  it('POST /odoo/cancel - Should cancel an order', async () => {
+    const body = new CancelOrderDto();
+    body.id = 1;
+    body.state = 'cancel';
+    body.order_line = mockOrderLineIds;
+
+    const spyPush = jest
+      .spyOn(mockStellarService, 'pushTransaction')
+      .mockReturnValueOnce(null);
+
+    await request(app.getHttpServer())
+      .post('/odoo/cancel')
+      .send(body)
+      .expect(HttpStatus.CREATED);
+
+    expect(spyPush).toBeCalledTimes(1);
+    expect(spyPush).toBeCalledWith(TRANSACTION_TYPE.CANCEL, body.id);
   });
 });

--- a/src/modules/odoo/interface/odoo.controller.ts
+++ b/src/modules/odoo/interface/odoo.controller.ts
@@ -1,11 +1,13 @@
 import { Body, Controller, Post } from '@nestjs/common';
 
-import { ConfirmOrderDto } from '@/modules/odoo/application/dto/confirm-order.dto';
-import { ConsolidateOrderDto } from '@/modules/odoo/application/dto/consolidate-order.dto';
-import { CreateOrderDto } from '@/modules/odoo/application/dto/create-order.dto';
-import { DeliverOrderDto } from '@/modules/odoo/application/dto/deliver-order.dto';
 import { StellarService } from '@/modules/stellar/application/services/stellar.service';
 import { TRANSACTION_TYPE } from '@/modules/stellar/domain/stellar-transaction.domain';
+
+import { CancelOrderDto } from '../application/dto/cancel-order.dto';
+import { ConfirmOrderDto } from '../application/dto/confirm-order.dto';
+import { ConsolidateOrderDto } from '../application/dto/consolidate-order.dto';
+import { CreateOrderDto } from '../application/dto/create-order.dto';
+import { DeliverOrderDto } from '../application/dto/deliver-order.dto';
 
 @Controller('odoo')
 export class OdooController {
@@ -40,5 +42,10 @@ export class OdooController {
   @Post('deliver')
   deliver(@Body() body: DeliverOrderDto): void {
     this.stellarService.pushTransaction(TRANSACTION_TYPE.DELIVER, body.sale_id);
+  }
+
+  @Post('cancel')
+  cancel(@Body() body: CancelOrderDto): void {
+    this.stellarService.pushTransaction(TRANSACTION_TYPE.CANCEL, body.id);
   }
 }

--- a/src/modules/stellar/domain/stellar-transaction.domain.ts
+++ b/src/modules/stellar/domain/stellar-transaction.domain.ts
@@ -5,6 +5,7 @@ export enum TRANSACTION_TYPE {
   CONFIRM = 'confirm',
   CONSOLIDATE = 'consolidate',
   DELIVER = 'deliver',
+  CANCEL = 'cancel',
 }
 
 export class StellarTransaction extends Base {

--- a/src/modules/stellar/interface/__test__/fixtures/stellar-transaction.yml
+++ b/src/modules/stellar/interface/__test__/fixtures/stellar-transaction.yml
@@ -65,3 +65,43 @@ items:
     orderId: 7777
     type: 'consolidate'
     timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction13:
+    hash: 'b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020'
+    orderId: 8888
+    type: 'create'
+    timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction14:
+    hash: 'b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020'
+    orderId: 9999
+    type: 'create'
+    timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction15:
+    hash: ''
+    orderId: 9999
+    type: 'confirm'
+    timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction16:
+    hash: 'b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020'
+    orderId: 1000
+    type: 'create'
+    timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction17:
+    hash: 'b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020'
+    orderId: 1000
+    type: 'confirm'
+    timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction18:
+    hash: 'b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020'
+    orderId: 1000
+    type: 'consolidate'
+    timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction19:
+    hash: 'b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020'
+    orderId: 1000
+    type: 'deliver'
+    timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction20:
+    hash: 'b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020'
+    orderId: 2000
+    type: 'create'
+    timestamp: '2021-01-01T00:00:00Z'

--- a/src/modules/stellar/interface/__test__/helpers/stellar.helper.ts
+++ b/src/modules/stellar/interface/__test__/helpers/stellar.helper.ts
@@ -64,6 +64,28 @@ export function createMockAccount(
   } as unknown as Horizon.AccountResponse;
 }
 
+export function createMockPayments(
+  from: string,
+  to: string,
+  amounts: IAssetAmount[],
+  issuer: string,
+): { records: Horizon.ServerApi.OperationRecord[] } {
+  return {
+    records: amounts.map(
+      (amount) =>
+        ({
+          type: Horizon.HorizonApi.OperationResponseType.payment,
+          from,
+          to,
+          amount: amount.quantity,
+          asset_code: amount.assetCode,
+          asset_issuer: issuer,
+          asset_type: 'credit_alphanum12',
+        } as unknown as Horizon.ServerApi.OperationRecord),
+    ),
+  };
+}
+
 export function hasSetFlagsOperation(operations: Operation[]) {
   const hasRequiredFlag = operations.some(
     (operation) => operation.type === 'setOptions' && operation.setFlags === 1,
@@ -143,5 +165,25 @@ export function hasClearBalanceOperation(
       return false;
     }
   }
+  return true;
+}
+
+export function hasClawbackOperation(
+  operations: Operation[],
+  assetCodes: string[],
+  from: string,
+): boolean {
+  for (const assetCode of assetCodes) {
+    const operation = operations.find(
+      (operation) =>
+        operation.type === 'clawback' &&
+        operation.from === from &&
+        operation.asset.code === assetCode,
+    );
+    if (!operation) {
+      return false;
+    }
+  }
+
   return true;
 }


### PR DESCRIPTION
> [!CAUTION]
> This PR adds a migration.

## Summary
This PR adds a retry loop for payment transactions, and implements a cancel method to execute a clawback operation.
Also, it adds an endpoint to be able to execute the cancelOrder functionality.