### PR TITLE
Feature/cancel transaction

### DIFF
--- a/data/migrations/1723485953319-add-cancel-transaction-type.ts
+++ b/data/migrations/1723485953319-add-cancel-transaction-type.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCancelTransactionType1723485953319
+  implements MigrationInterface
+{
+  name = 'AddCancelTransactionType1723485953319';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`stellar_transaction\` CHANGE \`type\` \`type\` enum ('create', 'confirm', 'consolidate', 'deliver', 'cancel') NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`stellar_transaction\` CHANGE \`type\` \`type\` enum ('create', 'confirm', 'consolidate', 'deliver') NOT NULL`,
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "cross-env NODE_ENV=automated_tests jest",
     "posttest": "rimraf -rf ./data/tests.*.*.db",
     "test:watch": "cross-env NODE_ENV=automated_tests jest --watch",
+    "posttest:cov": "rimraf -rf ./data/tests.*.*.db",
     "test:cov": "cross-env NODE_ENV=automated_tests jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli -d ./src/configuration/orm.configuration.ts",

--- a/src/common/application/exceptions/stellar.error.ts
+++ b/src/common/application/exceptions/stellar.error.ts
@@ -4,6 +4,7 @@ export enum ERROR_CODES {
   CONFIRM_ORDER_ERROR = 'CONFIRM_ORDER_ERROR',
   CONSOLIDATE_ORDER_ERROR = 'CONSOLIDATE_ORDER_ERROR',
   DELIVER_ORDER_ERROR = 'DELIVER_ORDER_ERROR',
+  CANCEL_ORDER_ERROR = 'CANCEL_ORDER_ERROR',
   GENERIC_ERROR = 'GENERIC_ERROR',
   ORDER_UNABLE_TO_CREATE_ERROR = 'ORDER_UNABLE_TO_CREATE_ERROR',
   ORDER_UNABLE_TO_CONFIRM_ERROR = 'ORDER_UNABLE_TO_CONFIRM_ERROR',
@@ -21,6 +22,7 @@ export const ERROR_MESSAGES: { [key in ERROR_CODES]: string } = {
     'An error occurred while consolidating order transaction',
   [ERROR_CODES.DELIVER_ORDER_ERROR]:
     'An error occurred while delivering order transaction',
+  [ERROR_CODES.CANCEL_ORDER_ERROR]: 'An error occurred while canceling order',
   [ERROR_CODES.GENERIC_ERROR]: 'An error occurred in the Stellar service',
   [ERROR_CODES.ORDER_UNABLE_TO_CREATE_ERROR]: 'The order cannot be created',
   [ERROR_CODES.ORDER_UNABLE_TO_CONFIRM_ERROR]: 'The order cannot be confirmed',

--- a/src/common/application/repository/stellar.repository.interface.ts
+++ b/src/common/application/repository/stellar.repository.interface.ts
@@ -16,4 +16,5 @@ export interface IStellarRepository {
   confirmOrder(amounts: IAssetAmount[]): Promise<ISubmittedTransaction>;
   consolidateOrder(amounts: IAssetAmount[]): Promise<ISubmittedTransaction>;
   deliverOrder(amounts: IAssetAmount[]): Promise<ISubmittedTransaction>;
+  cancelOrder(hash: string): Promise<ISubmittedTransaction>;
 }

--- a/src/common/infrastructure/stellar/nodes.enum.ts
+++ b/src/common/infrastructure/stellar/nodes.enum.ts
@@ -3,4 +3,5 @@ export enum TRACEABILITY_NODES {
   CONFIRM = '2',
   CONSOLIDATE = '3',
   DELIVER = '4',
+  CANCEL = '5',
 }

--- a/src/modules/odoo/application/dto/cancel-order.dto.ts
+++ b/src/modules/odoo/application/dto/cancel-order.dto.ts
@@ -1,0 +1,9 @@
+import { Equals } from 'class-validator';
+
+import { STATE } from '../services/odoo.state';
+import { SaleOrderDto } from './sale-order.dto';
+
+export class CancelOrderDto extends SaleOrderDto {
+  @Equals(STATE.CANCEL)
+  state: string;
+}

--- a/src/modules/odoo/application/dto/cancel-order.dto.ts
+++ b/src/modules/odoo/application/dto/cancel-order.dto.ts
@@ -1,9 +1,11 @@
-import { Equals } from 'class-validator';
+import { Equals, IsInt } from 'class-validator';
 
 import { STATE } from '../services/odoo.state';
-import { SaleOrderDto } from './sale-order.dto';
 
-export class CancelOrderDto extends SaleOrderDto {
+export class CancelOrderDto {
+  @IsInt()
+  id: number;
+
   @Equals(STATE.CANCEL)
   state: string;
 }

--- a/src/modules/odoo/application/services/odoo.state.ts
+++ b/src/modules/odoo/application/services/odoo.state.ts
@@ -3,4 +3,5 @@ export enum STATE {
   SALE = 'sale',
   ASSIGNED = 'assigned',
   DONE = 'done',
+  CANCEL = 'cancel',
 }

--- a/src/modules/odoo/interface/__test__/fixtures/stellar-transaction.yml
+++ b/src/modules/odoo/interface/__test__/fixtures/stellar-transaction.yml
@@ -65,3 +65,18 @@ items:
     orderId: 7777
     type: 'consolidate'
     timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction13:
+    hash: ''
+    orderId: 8888
+    type: 'create'
+    timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction14:
+    hash: 'b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020'
+    orderId: 9999
+    type: 'create'
+    timestamp: '2021-01-01T00:00:00Z'
+  stellarTransaction15:
+    hash: 'b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020'
+    orderId: 9999
+    type: 'cancel'
+    timestamp: '2021-01-01T00:00:00Z'

--- a/src/modules/odoo/interface/__test__/helpers/stellar.helper.ts
+++ b/src/modules/odoo/interface/__test__/helpers/stellar.helper.ts
@@ -42,6 +42,10 @@ export async function createMuxedAccounts(
       sourceAccount,
       TRACEABILITY_NODES.DELIVER,
     ).accountId(),
+    [TRACEABILITY_NODES.CANCEL]: new MuxedAccount(
+      sourceAccount,
+      TRACEABILITY_NODES.CANCEL,
+    ).accountId(),
   };
 }
 
@@ -133,8 +137,9 @@ export async function extractOperations(
   serverSpy: jest.SpyInstance<
     Promise<Horizon.HorizonApi.SubmitTransactionResponse>
   >,
+  resultIndex = 0,
 ): Promise<Operation[]> {
-  const { envelope_xdr } = (await serverSpy.mock.results[0]
+  const { envelope_xdr } = (await serverSpy.mock.results[resultIndex]
     .value) as Horizon.HorizonApi.SubmitTransactionResponse;
   const { operations } = new Transaction(
     envelope_xdr,

--- a/src/modules/odoo/interface/odoo.controller.ts
+++ b/src/modules/odoo/interface/odoo.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Post } from '@nestjs/common';
 
+import { CancelOrderDto } from '@/modules/odoo/application/dto/cancel-order.dto';
 import { ConfirmOrderDto } from '@/modules/odoo/application/dto/confirm-order.dto';
 import { ConsolidateOrderDto } from '@/modules/odoo/application/dto/consolidate-order.dto';
 import { CreateOrderDto } from '@/modules/odoo/application/dto/create-order.dto';
@@ -40,5 +41,10 @@ export class OdooController {
   @Post('deliver')
   deliver(@Body() body: DeliverOrderDto): void {
     this.stellarService.pushTransaction(TRANSACTION_TYPE.DELIVER, body.sale_id);
+  }
+
+  @Post('cancel')
+  cancel(@Body() body: CancelOrderDto): void {
+    this.stellarService.pushTransaction(TRANSACTION_TYPE.CANCEL, body.id);
   }
 }

--- a/src/modules/stellar/application/services/stellar.service.ts
+++ b/src/modules/stellar/application/services/stellar.service.ts
@@ -69,10 +69,33 @@ export class StellarService implements OnModuleInit {
     return amounts;
   }
 
+  private validateCancelTransaction(
+    transactions: StellarTransaction[],
+  ): boolean {
+    if (transactions.length === 0) {
+      return false;
+    }
+
+    const prevTransaction = transactions[transactions.length - 1];
+
+    if (
+      !prevTransaction.hash ||
+      prevTransaction.type === TRANSACTION_TYPE.CANCEL
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
   private validateTransaction(
     type: TRANSACTION_TYPE,
     transactions: StellarTransaction[],
   ): boolean {
+    if (type === TRANSACTION_TYPE.CANCEL) {
+      return this.validateCancelTransaction(transactions);
+    }
+
     const validationMap = {
       [TRANSACTION_TYPE.CREATE]: {
         length: 0,
@@ -150,6 +173,11 @@ export class StellarService implements OnModuleInit {
           break;
         case TRANSACTION_TYPE.DELIVER:
           transaction = await this.stellarRepository.deliverOrder(amounts);
+          break;
+        case TRANSACTION_TYPE.CANCEL:
+          transaction = await this.stellarRepository.cancelOrder(
+            transactions[transactions.length - 1].hash,
+          );
           break;
       }
 

--- a/src/modules/stellar/domain/stellar-transaction.domain.ts
+++ b/src/modules/stellar/domain/stellar-transaction.domain.ts
@@ -5,6 +5,7 @@ export enum TRANSACTION_TYPE {
   CONFIRM = 'confirm',
   CONSOLIDATE = 'consolidate',
   DELIVER = 'deliver',
+  CANCEL = 'cancel',
 }
 
 export class StellarTransaction extends Base {


### PR DESCRIPTION
> [!CAUTION]
> This PR adds a migration.

### Summary

This PR adds a cancel transaction for the traceability.

### Description
We added a new MuxedAccount as a CancelNode, and the steps to cancel an order are the followings:
1. Look for the last transaction for the order
2. Look for the payments associated with that transaction hash
3. Look for the destination associated with that transaction hash
4. Replicate the payments with the destination as the source account, and the CancelNode as the destination.